### PR TITLE
Ensure SSM always fetches parameters

### DIFF
--- a/spine_aws_common/lambda_application.py
+++ b/spine_aws_common/lambda_application.py
@@ -128,7 +128,7 @@ class LambdaApplication:
             env = os.environ.copy()
             process_name = env.get("AWS_LAMBDA_FUNCTION_NAME", "None")
             if load_ssm_params:
-                config = parameters.get_parameters(f"/{process_name}")
+                config = parameters.get_parameters(f"/{process_name}", force_fetch=True)
                 config.update(env)
                 return config
             return env


### PR DESCRIPTION
We hit this issue when unit testing a lambda usng the LambdaApplication
class and testing it with pytest and moto
When the tests were run together in the suite, there would always be a
failure of the second test as it was still seeing the same value as the
first, we now know this is due to aws_lambda_powertools cacheing SSM
parameters
This should be safe to set as in the real world, inside a running
Lambda lifecycle, this class will almost definitely only be initialised
once, meaning we'd get no benefit of having cached values anyway