### PR TITLE
Add CI build to PRs as well as commits

### DIFF
--- a/.github/workflows/continous-integration.yaml
+++ b/.github/workflows/continous-integration.yaml
@@ -1,6 +1,6 @@
 name: CI Build
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
When doing a PR from a fork, it doesn't take the CI-build result from the fork's commit, so we should do a CI-build on a PR otherwise the PR will remain hanging until manually merged by an admin.