### PR TITLE
Raise all exceptions

### DIFF
--- a/spine_aws_common/lambda_application.py
+++ b/spine_aws_common/lambda_application.py
@@ -62,14 +62,15 @@ class LambdaApplication:
                 print(e)
             else:
                 self.log_object.write_log("LAMBDAINIT001", None, {"message": e})
+            raise e
         except Exception as e:  # pylint:disable=broad-except
             if self.log_object is None:
                 print(e)
-                sys.exit(1)
             else:
                 self.log_object.write_log(
                     "LAMBDA9999", sys.exc_info(), {"error": str(e)}
                 )
+            raise e
 
         return self.response
 


### PR DESCRIPTION
This allows the Lambda runtime to see the exception and fail
Without this, we cannot make use of the built in Lambda retries, cannot
easily handle failing steps in Step Functions and struggle to test
negative case in integration testing