### PR TITLE
Single line Uncaught Exception logs

### DIFF
--- a/spine_aws_common/log/formatting.py
+++ b/spine_aws_common/log/formatting.py
@@ -45,9 +45,7 @@ def add_default_keys(log_row_dict):
 
 def create_log_preamble(log_level, process_name, log_reference):
     """Creates the string to form the initial part of any log message"""
-    return "Log_Level={} Process={} logReference={}".format(
-        log_level, process_name, log_reference
-    )
+    return f"Log_Level={log_level} Process={process_name} logReference={log_reference}"
 
 
 def can_encode_string(value):

--- a/spine_aws_common/log/spinelogging.py
+++ b/spine_aws_common/log/spinelogging.py
@@ -114,7 +114,7 @@ class SpineLogFormatter(logging.Formatter):
         """Format time"""
         converted_time = self.converter(record.created)
         time_str = time.strftime(datefmt, converted_time)
-        return "{}.{:0>3d}".format(time_str, int(record.msecs))
+        return f"{time_str}.{int(record.msecs):0>3d}"
 
 
 class SpineLogger(logging.Logger):

--- a/spine_aws_common/log/writer.py
+++ b/spine_aws_common/log/writer.py
@@ -31,7 +31,7 @@ def write_to_file(log_preamble, log_text, substitution_dict, log_type, error_lis
     """
     log_line = create_log_line(log_preamble, log_text, substitution_dict)
     if error_list:
-        log_line = "{} - {}".format(log_line, error_list[0:])
+        log_line = f"{log_line} - {error_list[0:]}"
 
     logging_func = _get_logging_function(log_type)
     if logging_func:

--- a/spine_aws_common/logger.py
+++ b/spine_aws_common/logger.py
@@ -222,18 +222,21 @@ class Logger:
         Writes the log out to the standard out for Cloudwatch logging
         """
         log_line = create_log_line(log_preamble, log_text, substitution_dict)
-
         if error_list is not None:
             log_line = log_line + " - " + str(error_list[0:])
-        log_line = log_line + "\r\n"
-
         print(log_line)
+
         if (
             log_type == LoggingConstants.LFR_CRASHDUMP
             and error_list
             and len(error_list) >= 3
         ):
-            traceback.print_exception(error_list[0], error_list[1], error_list[2], None)
+            exception, value, trace = error_list
+            formatted_exception = " ".join(
+                traceback.format_exception(exception, value, trace)
+            )
+            exception_line = create_log_line(log_preamble, formatted_exception, {})
+            print(exception_line)
 
 
 def configure_logging_adapter(log_object):

--- a/spine_aws_common/web_application.py
+++ b/spine_aws_common/web_application.py
@@ -60,7 +60,7 @@ class WebApplication(LambdaApplication):
     def _compile_regex(rule: str):
         """Precompile regex pattern"""
         rule_regex: str = re.sub(r"(<\w+>)", r"(?P\1.+)", rule)
-        return re.compile("^{}$".format(rule_regex))
+        return re.compile(f"^{rule_regex}$")
 
     def _resolve(self) -> ResponseBuilder:
         """Resolve response"""


### PR DESCRIPTION
`traceback.print_exception` prints out to file, with the `None` file
passed its outputs to stdout. This has now been replaced with a formatted
exception and also wraps the content in the standard log format