### PR TITLE
PCRM-5969 update the terraform providers

### DIFF
--- a/terraform/mesh_aws/terraform.tf
+++ b/terraform/mesh_aws/terraform.tf
@@ -8,15 +8,15 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
Update the terraform providers to >= rather than a fixed version to allow other projects to upgrade theirs if they are using this module.