### PR TITLE
use metadata from s3 bucket as header

### DIFF
--- a/mesh_aws_client/mesh_common.py
+++ b/mesh_aws_client/mesh_common.py
@@ -137,5 +137,6 @@ MeshMessage = namedtuple(
         "dest_mailbox",
         "workflow_id",
         "message_id",
+        "metadata",
     ],
 )

--- a/mesh_aws_client/mesh_mailbox.py
+++ b/mesh_aws_client/mesh_mailbox.py
@@ -27,6 +27,7 @@ class MeshMessage(NamedTuple):
     workflow_id: str = None
     message_id: str = None
     will_compress: bool = False
+    metadata: dict = None
 
 
 class HandshakeFailure(Exception):
@@ -244,6 +245,12 @@ class MeshMailbox:  # pylint: disable=too-many-instance-attributes
             session.headers["Content-Encoding"] = "gzip"
             session.headers["Mex-Content-Compress"] = "Y"
             session.headers["Mex-Content-Compressed"] = "Y"
+
+        # Add metadata beginning with mesh-header
+        for key, value in mesh_message_object.metadata:
+            if "mesh-header-" in key:
+                header_key = key.replace("mesh-header-", "")
+                session.headers[header_key] = value
 
         mesh_url = self.params[MeshMailbox.MESH_URL]
         if chunk_num == 1:

--- a/mesh_aws_client/mesh_send_message_chunk_application.py
+++ b/mesh_aws_client/mesh_send_message_chunk_application.py
@@ -128,6 +128,7 @@ class MeshSendMessageChunkApplication(
 
         file_response = self.s3_client.head_object(Bucket=self.bucket, Key=self.key)
         self.file_size = file_response["ContentLength"]
+        metadata = file_response.get("Metadata", {})
         self.log_object.write_log(
             "MESHSEND0005",
             None,
@@ -154,6 +155,7 @@ class MeshSendMessageChunkApplication(
             src_mailbox=self.mailbox.mailbox,
             workflow_id=self.mailbox.workflow_id,
             will_compress=self.will_compress,
+            metadata=metadata,
         )
         if self.file_size > 0:
             mailbox_response = self.mailbox.send_chunk(


### PR DESCRIPTION
Some services require that custom metadata is attached to MESH messages. User defined metadata can be attached to S3 objects. This PR suggests using S3 user-defined metadata on an S3 object matching the pattern "mesh-header-*" to use as mesh header data.