### PR TITLE
load mex headers from s3 metadata

### DIFF
--- a/mesh_aws_client/mesh_mailbox.py
+++ b/mesh_aws_client/mesh_mailbox.py
@@ -225,6 +225,19 @@ class MeshMailbox:  # pylint: disable=too-many-instance-attributes
             raise HandshakeFailure
         return response.status_code
 
+    def _headers_from_metadata(self, mesh_message_object: MeshMessage) -> dict:
+        headers = {}
+        if mesh_message_object.metadata is None:
+            return headers
+        if len(mesh_message_object.metadata.items()) == 0:
+            return headers
+
+        for key, value in mesh_message_object.metadata.items():
+            if "mex" in key.lower():
+                headers[key] = value
+
+        return headers
+
     def send_chunk(
         self,
         mesh_message_object: MeshMessage,
@@ -246,9 +259,8 @@ class MeshMailbox:  # pylint: disable=too-many-instance-attributes
             session.headers["Mex-Content-Compress"] = "Y"
             session.headers["Mex-Content-Compressed"] = "Y"
 
-        for key, value in mesh_message_object.metadata.items():
-            if "mex" in key.lower():
-                session.headers[key] = value
+        headers_from_metadata = self._headers_from_metadata(mesh_message_object)
+        session.headers.update(headers_from_metadata)
 
         mesh_url = self.params[MeshMailbox.MESH_URL]
         if chunk_num == 1:

--- a/mesh_aws_client/mesh_mailbox.py
+++ b/mesh_aws_client/mesh_mailbox.py
@@ -27,6 +27,7 @@ class MeshMessage(NamedTuple):
     workflow_id: str = None
     message_id: str = None
     will_compress: bool = False
+    metadata: dict = None
 
 
 class HandshakeFailure(Exception):
@@ -244,6 +245,10 @@ class MeshMailbox:  # pylint: disable=too-many-instance-attributes
             session.headers["Content-Encoding"] = "gzip"
             session.headers["Mex-Content-Compress"] = "Y"
             session.headers["Mex-Content-Compressed"] = "Y"
+
+        for key, value in mesh_message_object.metadata.items(): 
+            if "mex" in key:
+                session.headers[key] = value
 
         mesh_url = self.params[MeshMailbox.MESH_URL]
         if chunk_num == 1:

--- a/mesh_aws_client/mesh_mailbox.py
+++ b/mesh_aws_client/mesh_mailbox.py
@@ -246,7 +246,7 @@ class MeshMailbox:  # pylint: disable=too-many-instance-attributes
             session.headers["Mex-Content-Compress"] = "Y"
             session.headers["Mex-Content-Compressed"] = "Y"
 
-        for key, value in mesh_message_object.metadata.items(): 
+        for key, value in mesh_message_object.metadata.items():
             if "mex" in key:
                 session.headers[key] = value
 

--- a/mesh_aws_client/mesh_mailbox.py
+++ b/mesh_aws_client/mesh_mailbox.py
@@ -8,7 +8,7 @@ import platform
 import tempfile
 import uuid
 from hashlib import sha256
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import requests
 import urllib3
@@ -27,7 +27,7 @@ class MeshMessage(NamedTuple):
     workflow_id: str = None
     message_id: str = None
     will_compress: bool = False
-    metadata: dict = None
+    metadata: Optional[dict] = None
 
 
 class HandshakeFailure(Exception):
@@ -247,7 +247,7 @@ class MeshMailbox:  # pylint: disable=too-many-instance-attributes
             session.headers["Mex-Content-Compressed"] = "Y"
 
         for key, value in mesh_message_object.metadata.items():
-            if "mex" in key:
+            if "mex" in key.lower():
                 session.headers[key] = value
 
         mesh_url = self.params[MeshMailbox.MESH_URL]

--- a/mesh_aws_client/mesh_send_message_chunk_application.py
+++ b/mesh_aws_client/mesh_send_message_chunk_application.py
@@ -118,7 +118,7 @@ class MeshSendMessageChunkApplication(
     def _get_metadata_from_s3(self):
         """Get metadata from s3 object"""
         response = self.s3_client.head_object(Bucket=self.bucket, Key=self.key)
-        metadata = response.get("Metadata", None)
+        metadata = response.get("Metadata", {})
         return metadata
 
     def start(self):

--- a/mesh_aws_client/mesh_send_message_chunk_application.py
+++ b/mesh_aws_client/mesh_send_message_chunk_application.py
@@ -115,6 +115,12 @@ class MeshSendMessageChunkApplication(
             else:
                 yield file_content
 
+    def _get_metadata_from_s3(self):
+        """Get metadata from s3 object"""
+        response = self.s3_client.head_object(Bucket=self.bucket, Key=self.key)
+        metadata = response.get("Metadata", None)
+        return metadata
+
     def start(self):
         """Main body of lambda"""
 
@@ -149,6 +155,7 @@ class MeshSendMessageChunkApplication(
         message_object = MeshMessage(
             file_name=os.path.basename(self.key),
             data=self._get_file_from_s3(),
+            metadata=self._get_metadata_from_s3(),
             message_id=message_id,
             dest_mailbox=self.mailbox.dest_mailbox,
             src_mailbox=self.mailbox.mailbox,

--- a/mesh_aws_client/tests/mesh_send_message_chunk_application_test.py
+++ b/mesh_aws_client/tests/mesh_send_message_chunk_application_test.py
@@ -144,6 +144,9 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 }
             ),
         )
+        custom_request_headers = {
+            "mex-subject": "Custom Subject",
+        }
         response_mocker.post(
             "/messageexchange/MESH-TEST2/outbox",
             text=json.dumps({"messageID": "20210711164906010267_97CCD9"}),
@@ -152,9 +155,7 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "33",
                 "Connection": "keep-alive",
             },
-            request_headers={
-                "mex-subject": "Custom Subject",
-            },
+            request_headers=custom_request_headers,
         )
         response_mocker.post(
             "/messageexchange/MESH-TEST2/outbox/20210711164906010267_97CCD9/2",
@@ -164,9 +165,7 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "33",
                 "Connection": "keep-alive",
             },
-            request_headers={
-                "mex-subject": "Custom Subject",
-            },
+            request_headers=custom_request_headers,
         )
         response_mocker.post(
             "/messageexchange/MESH-TEST2/outbox/20210711164906010267_97CCD9/3",
@@ -176,9 +175,7 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "33",
                 "Connection": "keep-alive",
             },
-            request_headers={
-                "mex-subject": "Custom Subject",
-            },
+            request_headers=custom_request_headers,
         )
         response_mocker.post(
             "/messageexchange/MESH-TEST2/outbox/20210711164906010267_97CCD9/4",
@@ -188,9 +185,7 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "33",
                 "Connection": "keep-alive",
             },
-            request_headers={
-                "mex-subject": "Custom Subject",
-            },
+            request_headers=custom_request_headers,
         )
         s3_client = boto3.client("s3", config=MeshTestingCommon.aws_config)
         ssm_client = boto3.client("ssm", config=MeshTestingCommon.aws_config)

--- a/mesh_aws_client/tests/mesh_send_message_chunk_application_test.py
+++ b/mesh_aws_client/tests/mesh_send_message_chunk_application_test.py
@@ -75,6 +75,9 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "44",
                 "Connection": "keep-alive",
             },
+            request_headers={
+                "mex-subject": "Custom Subject",
+            },
         )
         s3_client = boto3.client("s3", config=MeshTestingCommon.aws_config)
         ssm_client = boto3.client("ssm", config=MeshTestingCommon.aws_config)
@@ -149,6 +152,9 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "33",
                 "Connection": "keep-alive",
             },
+            request_headers={
+                "mex-subject": "Custom Subject",
+            },
         )
         response_mocker.post(
             "/messageexchange/MESH-TEST2/outbox/20210711164906010267_97CCD9/2",
@@ -157,6 +163,9 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Type": "application/json",
                 "Content-Length": "33",
                 "Connection": "keep-alive",
+            },
+            request_headers={
+                "mex-subject": "Custom Subject",
             },
         )
         response_mocker.post(
@@ -167,6 +176,9 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Length": "33",
                 "Connection": "keep-alive",
             },
+            request_headers={
+                "mex-subject": "Custom Subject",
+            },
         )
         response_mocker.post(
             "/messageexchange/MESH-TEST2/outbox/20210711164906010267_97CCD9/4",
@@ -175,6 +187,9 @@ class TestMeshSendMessageChunkApplication(MeshTestCase):
                 "Content-Type": "application/json",
                 "Content-Length": "33",
                 "Connection": "keep-alive",
+            },
+            request_headers={
+                "mex-subject": "Custom Subject",
             },
         )
         s3_client = boto3.client("s3", config=MeshTestingCommon.aws_config)

--- a/mesh_aws_client/tests/mesh_testing_common.py
+++ b/mesh_aws_client/tests/mesh_testing_common.py
@@ -91,6 +91,9 @@ class MeshTestingCommon:
             Bucket=f"{environment}-mesh",
             Key="MESH-TEST2/outbound/testfile.json",
             Body=file_content,
+            Metadata={
+                "Mex-subject": "Custom Subject",
+            },
         )
 
     @staticmethod


### PR DESCRIPTION
Some recipients of MESH messages require custom "mex" headers in the message.  This pull request add support for custom mex headers by attaching them as metadata to the s3 object that the mesh_aws_client picks up. This only picks up metadata containing "mex" in the key.