### PR TITLE
Only create s3 vpc endpoint data source when needed

### DIFF
--- a/terraform/mesh_aws/data.tf
+++ b/terraform/mesh_aws/data.tf
@@ -2,6 +2,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_vpc_endpoint" "s3" {
+  count        = var.config.vpc_id == "" ? 0 : 1
   vpc_id       = var.config.vpc_id
   service_name = "com.amazonaws.eu-west-2.s3"
 }

--- a/terraform/mesh_aws/lambda_check_send_parameters.tf
+++ b/terraform/mesh_aws/lambda_check_send_parameters.tf
@@ -19,7 +19,7 @@ resource "aws_security_group" "check_send_parameters" {
       var.config.aws_kms_endpoints_sg_id,
       var.config.aws_lambda_endpoints_sg_id
     )
-    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]
+    prefix_list_ids = [data.aws_vpc_endpoint.s3[0].prefix_list_id]
   }
 }
 

--- a/terraform/mesh_aws/lambda_fetch_message_chunk.tf
+++ b/terraform/mesh_aws/lambda_fetch_message_chunk.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "fetch_message_chunk" {
       var.config.aws_kms_endpoints_sg_id,
       var.config.aws_lambda_endpoints_sg_id
     )
-    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]
+    prefix_list_ids = [data.aws_vpc_endpoint.s3[0].prefix_list_id]
   }
 }
 

--- a/terraform/mesh_aws/lambda_send_message_chunk.tf
+++ b/terraform/mesh_aws/lambda_send_message_chunk.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_function" "send_message_chunk" {
 
   environment {
     variables = {
-      Environment         = local.name
+      Environment = local.name
       use_secrets_manager = var.config.use_secrets_manager
     }
   }

--- a/terraform/mesh_aws/lambda_send_message_chunk.tf
+++ b/terraform/mesh_aws/lambda_send_message_chunk.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "send_message_chunk" {
       var.config.aws_kms_endpoints_sg_id,
       var.config.aws_lambda_endpoints_sg_id
     )
-    prefix_list_ids = [data.aws_vpc_endpoint.s3.prefix_list_id]
+    prefix_list_ids = [data.aws_vpc_endpoint.s3[0].prefix_list_id]
   }
 }
 
@@ -43,7 +43,7 @@ resource "aws_lambda_function" "send_message_chunk" {
 
   environment {
     variables = {
-      Environment = local.name
+      Environment         = local.name
       use_secrets_manager = var.config.use_secrets_manager
     }
   }

--- a/terraform/mesh_aws/s3_logs.tf
+++ b/terraform/mesh_aws/s3_logs.tf
@@ -1,7 +1,6 @@
 #tfsec:ignore:aws-cloudtrail-require-bucket-access-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "s3logs" {
   bucket = "${local.name}-s3logs"
-  acl    = "log-delivery-write"
   policy = data.aws_iam_policy_document.s3logs.json
 
   server_side_encryption_configuration {
@@ -30,6 +29,16 @@ resource "aws_s3_bucket_public_access_block" "s3logs" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_acl" "s3logs" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.s3logs,
+    aws_s3_bucket_ownership_controls.s3logs,
+  ]
+
+  bucket = aws_s3_bucket.s3logs.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_ownership_controls" "s3logs" {

--- a/terraform/mesh_aws/s3_logs.tf
+++ b/terraform/mesh_aws/s3_logs.tf
@@ -38,7 +38,7 @@ resource "aws_s3_bucket_acl" "s3logs" {
   ]
 
   bucket = aws_s3_bucket.s3logs.id
-  acl    = "private"
+  acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket_ownership_controls" "s3logs" {

--- a/terraform/mesh_aws/s3_logs.tf
+++ b/terraform/mesh_aws/s3_logs.tf
@@ -1,5 +1,8 @@
 #tfsec:ignore:aws-cloudtrail-require-bucket-access-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "s3logs" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.s3logs,
+  ]
   bucket = "${local.name}-s3logs"
   acl    = "log-delivery-write"
   policy = data.aws_iam_policy_document.s3logs.json
@@ -30,6 +33,13 @@ resource "aws_s3_bucket_public_access_block" "s3logs" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "s3logs" {
+  bucket = aws_s3_bucket.s3logs.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 data "aws_iam_policy_document" "s3logs" {

--- a/terraform/mesh_aws/s3_logs.tf
+++ b/terraform/mesh_aws/s3_logs.tf
@@ -1,8 +1,5 @@
 #tfsec:ignore:aws-cloudtrail-require-bucket-access-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "s3logs" {
-  depends_on = [
-    aws_s3_bucket_ownership_controls.s3logs,
-  ]
   bucket = "${local.name}-s3logs"
   acl    = "log-delivery-write"
   policy = data.aws_iam_policy_document.s3logs.json

--- a/terraform/mesh_aws/s3_mesh.tf
+++ b/terraform/mesh_aws/s3_mesh.tf
@@ -1,7 +1,4 @@
 resource "aws_s3_bucket" "mesh" {
-  depends_on = [
-    aws_s3_bucket_ownership_controls.mesh,
-  ]
   bucket = local.name
   acl    = "private"
 

--- a/terraform/mesh_aws/s3_mesh.tf
+++ b/terraform/mesh_aws/s3_mesh.tf
@@ -1,4 +1,7 @@
 resource "aws_s3_bucket" "mesh" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.mesh,
+  ]
   bucket = local.name
   acl    = "private"
 
@@ -16,7 +19,7 @@ resource "aws_s3_bucket" "mesh" {
     }
   }
 
-    lifecycle_rule {
+  lifecycle_rule {
     id      = "ExpireMeshObjects"
     enabled = var.mesh_s3_object_expiry_enabled
 
@@ -42,6 +45,13 @@ resource "aws_s3_bucket_public_access_block" "mesh" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "mesh" {
+  bucket = aws_s3_bucket.mesh.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_policy" "mesh_bucket_policy" {


### PR DESCRIPTION
When trying to source this module we found that the data source for the s3 endpoint in data.tf caused terraform to error because we already had an s3 vpc endpoint defined and managed in our MNS codebase. 

This PR just makes it such that where we're not using the vpc side of the config it won't create that data resource.

Also added fix for the change outlined here that AWS implemented earlier this year: https://github.com/hashicorp/terraform-provider-aws/issues/28353